### PR TITLE
Fix releaser metrics

### DIFF
--- a/shipyard/monitoring/files/grafana/dashboards/payments.json
+++ b/shipyard/monitoring/files/grafana/dashboards/payments.json
@@ -832,7 +832,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "sum by (envoy_response_code) (rate(envoy_cluster_upstream_rq{envoy_cluster_name=\"local_app\", job=~\"payments-deployment\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_response_code) (rate(envoy_cluster_upstream_rq{local_cluster=\"payments\", job=~\"payments-deployment\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Canary - {{envoy_response_code}}",
           "refId": "A"
@@ -843,7 +843,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "sum by (envoy_response_code) (rate(envoy_cluster_upstream_rq{job=~\"payments-primary\",envoy_cluster_name=\"local_app\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_response_code) (rate(envoy_cluster_upstream_rq{job=~\"payments-primary\",local_cluster=\"payments\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Primary - {{envoy_response_code}}",
           "refId": "B"

--- a/shipyard/monitoring/prometheus.hcl
+++ b/shipyard/monitoring/prometheus.hcl
@@ -50,6 +50,8 @@ template "prometheus_config" {
     params:
       format:
       - "prometheus"
+    scrape_interval: 15s
+    scrape_timeout: 5s
     consul_sd_configs:
     - server: "${var.consul_url}"
       tags:

--- a/src/main/java/com/hashicorp/hashicraft/block/entity/ConsulReleaserRenderer.java
+++ b/src/main/java/com/hashicorp/hashicraft/block/entity/ConsulReleaserRenderer.java
@@ -95,7 +95,7 @@ public class ConsulReleaserRenderer<T extends ConsulReleaserEntity> implements B
         } else if (message.contentEquals(STATUS_FAILED)) {
             color = 0xFFd6510f;
             renderStatus(matrices, direction, light, overlay, FAILURE_TEXTURE);
-        } else if (!message.contentEquals(STATUS_IDLE)) {
+        } else if (!message.contentEquals(STATUS_IDLE) && !message.contentEquals(STATUS_NOT_CONFIGURED)) {
             renderStatus(matrices, direction, light, overlay, PROGRESS_TEXTURE);
         }
 

--- a/src/main/java/com/hashicorp/hashicraft/entity/AppMinecartEntityRenderer.java
+++ b/src/main/java/com/hashicorp/hashicraft/entity/AppMinecartEntityRenderer.java
@@ -23,6 +23,8 @@ import net.minecraft.util.math.Quaternion;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.Vec3f;
 
+import java.util.Optional;
+
 @Environment(value = EnvType.CLIENT)
 public class AppMinecartEntityRenderer extends EntityRenderer<AppMinecartEntity> {
     private static final Identifier TEXTURE = Mod.identifier("textures/entity/app_minecart.png");
@@ -78,12 +80,23 @@ public class AppMinecartEntityRenderer extends EntityRenderer<AppMinecartEntity>
         this.model.render(matrixStack, vertexConsumer, i, OverlayTexture.DEFAULT_UV, 1.0f, 1.0f, 1.0f, 1.0f);
         matrixStack.pop();
 
+
         Text allocation = entity.getAllocationID();
-        renderAllocation(matrixStack, f, allocation, 0.0f, 1.85f, 0.0f, 0.02F);
+        Text truncatedAllocation = truncateAllocation(allocation);
+        renderAllocation(matrixStack, f, truncatedAllocation, 0.0f, 1.85f, 0.0f, 0.02F);
         Text application = entity.getApplication();
         renderName(matrixStack, f, application, 0.0f, 1.6f, 0.0f, 0.03F);
         Text version = entity.getVersion();
         renderVersion(matrixStack, f, version, 0.0f, 1.3f, 0.0f, 0.02F);
+    }
+
+    private Text truncateAllocation(Text allocation) {
+        if (allocation != null) {
+            String alloc = allocation.getString();
+            String truncated = alloc.substring(0, Math.min(alloc.length(), 8));
+            return Text.literal(truncated);
+        }
+        return Text.literal("");
     }
 
     private void renderAllocation(MatrixStack matrices, float rotation, Text text, float x, float y, float z,


### PR DESCRIPTION
Metrics had an issue where query labels changed, specifically for `envoy_cluster_name`.
This affects two places:

1. Grafana dashboard
2. Consul releaser configuration - do not use preset

Additional fixes include truncating Nomad allocations to 8 characters for rendering and updates to releaser logic to show  an unconfigured block.